### PR TITLE
WIP: Migration of spring-controller

### DIFF
--- a/generators/spring-controller/USAGE
+++ b/generators/spring-controller/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Creates a new simple spring REST MVC controller written on Kotlin.
+
+Example:
+    jhipster spring-controller Foo
+
+    This will create:
+        src/main/kotlin/package/web/rest/FooResource.kt with API on "api/foo"

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2013-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require('lodash');
+const chalk = require('chalk');
+const BaseGenerator = require('../generator-jhipster');
+const constants = require('../generator-constants');
+const prompts = require('./prompts');
+
+const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
+const SERVER_TEST_SRC_DIR = constants.SERVER_TEST_SRC_DIR;
+
+module.exports = class extends BaseGenerator {
+    constructor(args, opts) {
+        super(args, opts);
+        this.argument('name', { type: String, required: true });
+        this.name = this.options.name;
+    }
+
+    initializing() {
+        this.log(`The spring-controller ${this.name} is being created.`);
+        this.baseName = this.config.get('baseName');
+        this.packageName = this.config.get('packageName');
+        this.packageFolder = this.config.get('packageFolder');
+        this.databaseType = this.config.get('databaseType');
+        this.controllerActions = [];
+    }
+
+    get prompting() {
+        return {
+            askForControllerActions: prompts.askForControllerActions
+        };
+    }
+
+    get default() {
+        return {
+            insight() {
+                const insight = this.insight();
+                insight.trackWithEvent('generator', 'spring-controller');
+            }
+        };
+    }
+
+    writing() {
+        this.controllerClass = _.upperFirst(this.name);
+        this.controllerInstance = _.lowerFirst(this.name);
+        this.apiPrefix = _.kebabCase(this.name);
+
+        if (this.controllerActions.length === 0) {
+            this.log(chalk.green('No controller actions found, addin a default action'));
+            this.controllerActions.push({
+                actionName: 'defaultAction',
+                actionMethod: 'Get'
+            });
+        }
+
+        // helper for Java imports
+        this.usedMethods = _.uniq(this.controllerActions.map(action => action.actionMethod));
+        this.usedMethods = this.usedMethods.sort();
+
+        this.mappingImports = this.usedMethods.map(method => `org.springframework.web.bind.annotation.${method}Mapping`);
+        this.mockRequestImports = this.usedMethods.map(method => `static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.${method.toLowerCase()}`);
+
+        // IntelliJ optimizes imports after a certain count
+        this.mockRequestImports = this.mockRequestImports.length > 3 ? ['static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*'] : this.mockRequestImports;
+
+        this.mainClass = this.getMainClassName();
+
+        this.controllerActions.forEach((action) => {
+            action.actionPath = _.kebabCase(action.actionName);
+            action.actionNameUF = _.upperFirst(action.actionName);
+            this.log(chalk.green(`adding ${action.actionMethod} action '${action.actionName}' for /api/${this.apiPrefix}/${action.actionPath}`));
+        });
+
+        this.template(
+            `${SERVER_MAIN_SRC_DIR}package/web/rest/Resource.kt.ejs`,
+            `${SERVER_MAIN_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}Resource.kt`
+        );
+
+        this.template(
+            `${SERVER_TEST_SRC_DIR}package/web/rest/ResourceIntTest.kt.ejs`,
+            `${SERVER_TEST_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}ResourceIntTest.kt`
+        );
+    }
+};

--- a/generators/spring-controller/prompts.js
+++ b/generators/spring-controller/prompts.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2013-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const jhiCore = require('jhipster-core');
+
+module.exports = {
+    askForControllerActions
+};
+
+function askForControllerActions() {
+    const askForControllerAction = (done) => {
+        const prompts = [
+            {
+                type: 'confirm',
+                name: 'actionAdd',
+                message: 'Do you want to add an action to your controller?',
+                default: true
+            },
+            {
+                when: response => response.actionAdd === true,
+                type: 'input',
+                name: 'actionName',
+                validate: (input) => {
+                    if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
+                        return 'Your action name cannot contain special characters';
+                    } else if (input === '') {
+                        return 'Your action name cannot be empty';
+                    } else if (input.charAt(0) === input.charAt(0).toUpperCase()) {
+                        return 'Your action name cannot start with an upper case letter';
+                    } else if (jhiCore.isReservedFieldName(input)) {
+                        return 'Your action name cannot contain a Kotlin or Angular reserved keyword';
+                    }
+
+                    return true;
+                },
+                message: 'What is the name of your action?'
+            },
+            {
+                when: response => response.actionAdd === true,
+                type: 'list',
+                name: 'actionMethod',
+                message: 'What is the HTTP method of your action?',
+                choices: [
+                    {
+                        name: 'POST',
+                        value: 'Post'
+                    },
+                    {
+                        name: 'GET',
+                        value: 'Get'
+                    },
+                    {
+                        name: 'PUT',
+                        value: 'Put'
+                    },
+                    {
+                        name: 'DELETE',
+                        value: 'Delete'
+                    }
+                ],
+                default: 1
+            }
+        ];
+
+        this.prompt(prompts).then((props) => {
+            if (props.actionAdd) {
+                const controllerAction = {
+                    actionName: props.actionName,
+                    actionMethod: props.actionMethod
+                };
+
+                this.controllerActions.push(controllerAction);
+
+                askForControllerAction(done);
+            } else {
+                done();
+            }
+        });
+    };
+
+    const done = this.async();
+    askForControllerAction(done);
+}
+

--- a/generators/spring-controller/templates/src/main/java/package/web/rest/Resource.kt.ejs
+++ b/generators/spring-controller/templates/src/main/java/package/web/rest/Resource.kt.ejs
@@ -1,0 +1,51 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.rest
+
+import org.slf4j.LoggerFactory
+<%_ if (mappingImports.length > 2) { _%>
+import org.springframework.web.bind.annotation.*
+<%_ } else { _%>
+<%_ for(let idx in mappingImports) { _%>
+import <%= mappingImports[idx] %>;
+<%_ } _%>
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+<%_ } _%>
+
+/**
+ * <%= controllerClass %> controller
+ */
+@RestController
+@RequestMapping("/api/<%= apiPrefix %>")
+class <%= controllerClass %>Resource {
+
+    private val log = LoggerFactory.getLogger(<%= controllerClass %>Resource::class.java);
+
+    <%_ for(let idx in controllerActions) { _%>
+    /**
+    * <%= controllerActions[idx].actionMethod.toUpperCase() %> <%= controllerActions[idx].actionName %>
+    */
+    @<%= controllerActions[idx].actionMethod %>Mapping("/<%= (controllerActions[idx].actionPath) %>")
+    fun <%= controllerActions[idx].actionName %>(): String {
+        return "<%= controllerActions[idx].actionName %>";
+    }
+
+    <%_ } _%>
+}

--- a/generators/spring-controller/templates/src/test/java/package/web/rest/ResourceIntTest.kt.ejs
+++ b/generators/spring-controller/templates/src/test/java/package/web/rest/ResourceIntTest.kt.ejs
@@ -1,0 +1,68 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.rest;
+
+import <%=packageName%>.<%= mainClass %>;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+
+<%_ for(let idx in mockRequestImports) { _%>
+import <%= mockRequestImports[idx] %>;
+<%_ } _%>
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+/**
+ * Test class for the <%= controllerClass %> REST controller.
+ *
+ * @see <%= controllerClass %>Resource
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = <%= mainClass %>.class)
+public class <%= controllerClass %>ResourceIntTest {
+
+    private MockMvc restMockMvc;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        <%= controllerClass %>Resource <%= controllerInstance %>Resource = new <%= controllerClass %>Resource();
+        restMockMvc = MockMvcBuilders
+            .standaloneSetup(<%= controllerInstance %>Resource)
+            .build();
+    }
+
+    <%_ for(let idx in controllerActions) { _%>
+    /**
+    * Test <%= controllerActions[idx].actionName %>
+    */
+    @Test
+    public void test<%= controllerActions[idx].actionNameUF %>() throws Exception {
+        restMockMvc.perform(<%= controllerActions[idx].actionMethod.toLowerCase() %>("/api/<%= apiPrefix %>/<%= controllerActions[idx].actionPath %>"))
+            .andExpect(status().isOk());
+    }
+    <%_ } _%>
+
+}


### PR DESCRIPTION
List of things that are not ready yet:

- [ ] Once we figure out how to properly test `jhipster-kotlin` locally, `USAGE` has to be updated accordingly.
- [ ] `prompts.js` maybe needs an update on [`jhipster-core`](https://github.com/jhipster/jhipster-core/pull/186) first
- [ ] Migrate the controller's tests

Once not a WIP anymore, should resolve #9 