### PR TITLE
CI: prepare the change of generate entities script with JDL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ env:
     - JHI_PROFILE=dev
     - JHI_RUN_APP=1
     - JHI_PROTRACTOR=0
+    - JHI_ENTITY=sql
     # if JHI_LIB_BRANCH value is release, use the release from Maven
     - JHI_LIB_REPO=https://github.com/jhipster/jhipster.git
     - JHI_LIB_BRANCH=release


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/pull/8773
I think sub generator entities for Kotlin is not ready yet, but it's for preparing the future