### PR TITLE
Switch JHipster branch to v5.x_maintenance to avoid CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
     - JHI_LIB_BRANCH=release
     # if JHI_GEN_BRANCH value is release, use the release from NPM
     - JHI_GEN_REPO=https://github.com/jhipster/generator-jhipster.git
-    - JHI_GEN_BRANCH=master
+    - JHI_GEN_BRANCH=v5.x_maintenance
     # specific config
     - SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
     - SPRING_JPA_SHOW_SQL=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     JHI_LIB_BRANCH: release
     # if JHI_GEN_BRANCH value is release, use the release from NPM
     JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
-    JHI_GEN_BRANCH: master
+    JHI_GEN_BRANCH: v5.x_maintenance
     # specific config
     SPRING_OUTPUT_ANSI_ENABLED: NEVER
     SPRING_JPA_SHOW_SQL: false


### PR DESCRIPTION
Switch JHipster branch to [v5.x_maintenance](https://github.com/jhipster/generator-jhipster/tree/v5.x_maintenance) to avoid CI errors