### PR TITLE
Update to JHipster 6.0.0 beta.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ services:
 language: node_js
 node_js:
     - '10.15.3'
-jdk:
-    - openjdk11
 addons:
     apt:
         sources:
@@ -41,6 +39,7 @@ env:
         - JHI_PROFILE=dev
         - JHI_RUN_APP=1
         - JHI_PROTRACTOR=0
+        - JHI_JDK=8
         # if JHI_LIB_BRANCH value is release, use the release from Maven
         - JHI_LIB_REPO=https://github.com/jhipster/jhipster.git
         - JHI_LIB_BRANCH=master
@@ -56,19 +55,29 @@ env:
         - KOTLIN_JHI_SCRIPTS=$TRAVIS_BUILD_DIR/test-integration/scripts
     matrix:
         - JHI_APP=kotlin-jdl-default JHI_ENTITY=jdl JHI_PROFILE=prod JHI_PROTRACTOR=1
-        - JHI_APP=ngx-default JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_SONAR=1
         - JHI_APP=ngx-psql-es-noi18n JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sqlfull
         - JHI_APP=ngx-gradle-fr JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_WAR=1
-        - JHI_APP=ngx-mariadb-oauth2-sass-infinispan JHI_PROTRACTOR=1 JHI_ENTITY=sql
         - JHI_APP=ms-ngx-gateway-eureka JHI_ENTITY=sql JHI_WAR=1
         - JHI_APP=ms-micro-eureka JHI_ENTITY=micro JHI_WAR=1
+        - JHI_APP=ms-micro-consul JHI_ENTITY=micro
         - JHI_APP=ngx-mongodb-kafka-cucumber JHI_ENTITY=mongodb
+        - JHI_APP=ngx-session-cassandra-fr JHI_ENTITY=cassandra
+        - JHI_APP=ngx-couchbase JHI_PROFILE=prod JHI_ENTITY=couchbase
 
 #----------------------------------------------------------------------
 # Install all tools and check configuration
 #----------------------------------------------------------------------
 before_install:
-    - jdk_switcher use oraclejdk8
+    - |
+        if [[ $JHI_JDK = '11' ]]; then
+            echo '*** Using OpenJDK 11'
+            curl -s get.sdkman.io | bash
+            echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+            source "$HOME/.sdkman/bin/sdkman-init.sh"
+            sdk install java 11.0.2-open
+        else
+            echo '*** Using OpenJDK 8 by default'
+        fi
     - java -version
     - export TZ=Australia/Canberra
     - date
@@ -79,6 +88,8 @@ before_install:
     - sh -e /etc/init.d/xvfb start
     # Update NPM
     - npm install -g npm
+    # Install Yarn
+    - npm install -g yarn
     - $KOTLIN_JHI_SCRIPTS/04-git-config.sh
 
 #----------------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ env:
         - KOTLIN_JHI_SCRIPTS=$TRAVIS_BUILD_DIR/test-integration/scripts
     matrix:
         - JHI_APP=kotlin-jdl-default JHI_ENTITY=jdl JHI_PROFILE=prod JHI_PROTRACTOR=1
-        - JHI_APP=ngx-psql-es-noi18n JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sqlfull
+        - JHI_APP=ngx-psql-es-noi18n-mapsid JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sqlfull
         - JHI_APP=ngx-gradle-fr JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_WAR=1
         - JHI_APP=ms-ngx-gateway-eureka JHI_ENTITY=sql JHI_WAR=1
         - JHI_APP=ms-micro-eureka JHI_ENTITY=micro JHI_WAR=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
           JHI_PROFILE: dev
           JHI_RUN_APP: 1
           JHI_PROTRACTOR: 0
+          JHI_JDK: 11
           # if JHI_LIB_BRANCH value is release, use the release from Maven
           JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
           JHI_LIB_BRANCH: master
@@ -41,6 +42,17 @@ jobs:
 
       strategy:
           matrix:
+              jdl-default:
+                  JHI_APP: jdl-default
+                  JHI_ENTITY: jdl
+                  JHI_PROFILE: prod
+                  JHI_PROTRACTOR: 1
+              jdl-default-jdk8:
+                  JHI_APP: jdl-default
+                  JHI_ENTITY: jdl
+                  JHI_PROFILE: prod
+                  JHI_PROTRACTOR: 1
+                  JHI_JDK: 8
               react-default:
                   JHI_APP: react-default
                   JHI_PROFILE: prod
@@ -61,19 +73,13 @@ jobs:
               ms-ngx-gateway-uaa:
                   JHI_APP: ms-ngx-gateway-uaa
                   JHI_ENTITY: uaa
-              ms-micro-consul:
-                  JHI_APP: ms-micro-consul
-                  JHI_ENTITY: micro
+              ngx-mariadb-oauth2-sass-infinispan:
+                  JHI_APP: ngx-mariadb-oauth2-sass-infinispan
+                  JHI_PROTRACTOR: 1
+                  JHI_ENTITY: sql
               ngx-h2mem-ws-nol2:
                   JHI_APP: ngx-h2mem-ws-nol2
                   JHI_ENTITY: sql
-              ngx-session-cassandra-fr:
-                  JHI_APP: ngx-session-cassandra-fr
-                  JHI_ENTITY: cassandra
-              ngx-couchbase:
-                  JHI_APP: ngx-couchbase
-                  JHI_PROFILE: prod
-                  JHI_ENTITY: couchbase
               webflux-mongodb:
                   JHI_APP: webflux-mongodb
                   JHI_ENTITY: mongodb
@@ -87,13 +93,27 @@ jobs:
                 versionSpec: '10.15.3'
             displayName: 'TOOLS: install Node.js'
           - script: |
+                if [[ $JHI_JDK = '11' ]]; then
+                    echo '*** Using OpenJDK 11'
+                    curl -s get.sdkman.io | bash
+                    echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+                    source "$HOME/.sdkman/bin/sdkman-init.sh"
+                    sdk install java 11.0.2-open
+                    java --version
+                else
+                    echo '*** Using OpenJDK 8 by default'
+                fi
+            displayName: 'TOOLS: configuring OpenJDK'
+          - script: |
                 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
                 sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
                 sudo apt update
                 sudo apt install google-chrome-stable
             displayName: 'TOOLS: install google-chrome-stable'
-          - script: sudo npm install -g npm
+          - script: npm install -g npm
             displayName: 'TOOLS: update NPM'
+          - script: npm install -g yarn
+            displayName: 'TOOLS: install Yarn'
           - script: sudo chown -R vsts:docker /home/vsts/.npm/
             displayName: 'BUGS-FIX: change /home/vsts/.npm/ permission'
           - bash: $(KOTLIN_JHI_SCRIPTS)/01-display-configuration.sh

--- a/generators/entity-server/templates/src/main/kotlin/package/common/get_filtered_template.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/common/get_filtered_template.ejs
@@ -19,7 +19,7 @@
 <%
 const instanceType = (dto === 'mapstruct') ? asDto(entityClass) : asEntity(entityClass);
 const mapper = entityInstance  + 'Mapper';
-const entityToDtoReference = mapper + '::' + 'toDto';
+const entityToDtoReference = mapper + '.toDto(it)';
 for (const idx in relationships) { if (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide !== true) { %>
 
     /**

--- a/generators/entity-server/templates/src/main/kotlin/package/common/save_template.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/common/save_template.ejs
@@ -32,8 +32,8 @@ if (isUsingMapsId === true) {
     mapsIdRepoInstance = `${mapsIdEntityInstance}Repository`;
     otherEntityName = mapsIdAssoc.otherEntityName;
     if (isController === true) { _%>
-        if (Objects.isNull(<%= instanceName%>.get<%= mapsIdAssoc.relationshipNameCapitalized %> <%_ if (dto === 'mapstruct') { _%> Id <%_ } _%>())) {
-            throw new BadRequestAlertException("Invalid association value provided", ENTITY_NAME, "null");
+        if (Objects.isNull(<%= instanceName%>.<%= mapsIdAssoc.relationshipName %> <%_ if (dto === 'mapstruct') { _%> Id <%_ } _%>)) {
+            throw BadRequestAlertException("Invalid association value provided", ENTITY_NAME, "null")
         }
     <%_ } _%>
 <%_ }
@@ -42,14 +42,14 @@ if (!viaService) {
         resultEntity = asEntity(entityInstance) %>
         var <%= asEntity(entityInstance) %> = <%= dtoToEntity %>(<%= instanceName %>)
         <%_ if (isUsingMapsId === true) { _%>
-        val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipNameCapitalized %>Id()
+        val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipName%>Id
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= entityInstance%>::<%= otherEntityName %>)
         <%_ } _%>
         <%= asEntity(entityInstance) %> = <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)
         <%= returnPrefix %> <%= entityToDto %>(<%= asEntity(entityInstance) %>)
     <%_ } else { resultEntity = 'result'; _%>
         <%_ if (isUsingMapsId === true) { _%>
-        val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipNameCapitalized %>.id
+        val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipName %>.id
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= instanceName%>::<%= otherEntityName %>)
         <%_ } _%>
         <%= returnPrefix %> <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)
@@ -59,7 +59,7 @@ if (!viaService) {
         return result
     <%_ }}} else { _%>
         <%_ if (isUsingMapsId === true && isController === false) { _%>
-        val <%= otherEntityName %>Id = <%= entityInstance %>.<%= mapsIdAssoc.relationshipNameCapitalized %>.id
+        val <%= otherEntityName %>Id = <%= entityInstance %>.<%= mapsIdAssoc.relationshipName %>.id
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= entityInstance%>::<%= otherEntityName %>)
         <%_ } _%>
         <%= returnPrefix %> <%= entityInstance %>Service.save(<%= instanceName %>)

--- a/generators/entity-server/templates/src/main/kotlin/package/common/save_template.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/common/save_template.ejs
@@ -43,14 +43,20 @@ if (!viaService) {
         var <%= asEntity(entityInstance) %> = <%= dtoToEntity %>(<%= instanceName %>)
         <%_ if (isUsingMapsId === true) { _%>
         val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipName%>Id
-        <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= entityInstance%>::<%= otherEntityName %>)
+        if (<%= otherEntityName %>Id != null) {
+            <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id)
+                .ifPresent { <%= asEntity(entityInstance) %>.<%= otherEntityName %> = it }
+        }
         <%_ } _%>
         <%= asEntity(entityInstance) %> = <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)
         <%= returnPrefix %> <%= entityToDto %>(<%= asEntity(entityInstance) %>)
     <%_ } else { resultEntity = 'result'; _%>
         <%_ if (isUsingMapsId === true) { _%>
-        val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipName %>.id
-        <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= instanceName%>::<%= otherEntityName %>)
+        val <%= otherEntityName %>Id = <%= instanceName %>.<%= mapsIdAssoc.relationshipName %>?.id
+        if (<%= otherEntityName %>Id != null) {
+            <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id)
+                .ifPresent { <%= asEntity(entityInstance) %>.<%= otherEntityName %> = it }
+        }
         <%_ } _%>
         <%= returnPrefix %> <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)
         <%_ } if (searchEngine === 'elasticsearch') { _%>
@@ -59,8 +65,11 @@ if (!viaService) {
         return result
     <%_ }}} else { _%>
         <%_ if (isUsingMapsId === true && isController === false) { _%>
-        val <%= otherEntityName %>Id = <%= entityInstance %>.<%= mapsIdAssoc.relationshipName %>.id
-        <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= entityInstance%>::<%= otherEntityName %>)
+        val <%= otherEntityName %>Id = <%= entityInstance %>.<%= mapsIdAssoc.relationshipName %>?.id
+        if (<%= otherEntityName %>Id != null) {
+            <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id)
+                .ifPresent { <%= asEntity(entityInstance) %>.<%= otherEntityName %> = it }
+        }
         <%_ } _%>
         <%= returnPrefix %> <%= entityInstance %>Service.save(<%= instanceName %>)
 <%_ } _%>

--- a/generators/entity-server/templates/src/main/kotlin/package/domain/Entity.kt.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/domain/Entity.kt.ejs
@@ -284,7 +284,7 @@ for (var idx in fields) {
         const relationshipRequired = relationships[idx].relationshipRequired;
         const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
         const ownerSide = relationships[idx].ownerSide;
-        const useJPADerivedIdentifier = relationships[idx].useJPADerivedIdentifier;
+        const isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
         const comma = (parseInt(idx,10) === (relationships.length - 1)) ?  '' : ',';
         if (otherEntityRelationshipName) {
             mappedBy = otherEntityRelationshipName.charAt(0).toLowerCase() + otherEntityRelationshipName.slice(1)
@@ -311,6 +311,7 @@ for (var idx in fields) {
     @Field("<%= relationshipFieldName %>")
     <%_ } _%>
     var <%= relationshipFieldNamePlural %>: MutableSet<<%= asEntity(otherEntityNameCapitalized) %>> = mutableSetOf()<%= comma %>
+
     <%_ } else if (relationshipType === 'many-to-one') {
             if (databaseType === 'sql') {
     _%>
@@ -359,7 +360,7 @@ for (var idx in fields) {
             <%_ if (relationshipValidate) { _%>
     <%- include relationship_validators -%>
             <%_ }_%>
-            <%_ if (useJPADerivedIdentifier === true) { %>
+            <%_ if (isUsingMapsId === true) { %>
     @MapsId
     @JoinColumn(name = "id")
             <%_ } else { %>

--- a/generators/entity-server/templates/src/main/kotlin/package/domain/Entity.kt.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/domain/Entity.kt.ejs
@@ -107,6 +107,9 @@ import javax.persistence.ManyToMany
     <%_ if (fieldsContainManyToOne) { _%>
 import javax.persistence.ManyToOne
     <%_ } _%>
+    <%_ if (isUsingMapsId) { _%>
+import javax.persistence.MapsId
+    <%_ } _%>
     <%_ if (fieldsContainOneToMany) { _%>
 import javax.persistence.OneToMany
     <%_ } _%>

--- a/generators/entity-server/templates/src/main/kotlin/package/service/dto/EntityCriteria.kt.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/service/dto/EntityCriteria.kt.ejs
@@ -104,13 +104,36 @@ _%>
     var <%= filterVariable.name %>: <%- filterVariable.filterType %>? = null<%= comma %>
 <%_ }) _%>
 ) : Serializable, Criteria {
+
+    constructor(other: <%= entityClass %>Criteria) :
+        this(
+<%_
+    filterVariables.forEach((filterVariable, index) => {
+        const comma = (index===filterVariables.length-1) ? '' : ',';
+_%>
+            other.<%= filterVariable.name %>?.copy()<%= comma %>
+<%_ }); _%>
+        )
 <%_ Object.keys(extraFilters).forEach((key) => {
         extraFilter = extraFilters[key]; _%>
+
     /**
      * Class for filtering <%= key %>
      */
-    class <%= extraFilter.type %> : <%- extraFilter.superType %>()
+    class <%= extraFilter.type %> : <%- extraFilter.superType %> {
+        constructor()
+
+        constructor(filter: <%= extraFilter.type %>) : super(filter)
+
+        override fun copy(): <%= extraFilter.type %> {
+            return <%= extraFilter.type %>(this)
+        }
+    }
 <%_ }); _%>
+
+    override fun copy(): <%= entityClass %>Criteria {
+        return <%= entityClass %>Criteria(this)
+    }
 
     companion object {
         private const val serialVersionUID: Long = 1L

--- a/generators/entity-server/templates/src/main/kotlin/package/service/dto/EntityCriteria.kt.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/service/dto/EntityCriteria.kt.ejs
@@ -22,6 +22,7 @@ import java.io.Serializable
 <%_ if (fieldsContainDuration === true) { _%>
 import java.time.Duration
 <%_ } _%>
+import io.github.jhipster.service.Criteria;
 <%_ for (idx in fields) { if (fields[idx].fieldIsEnum === true) { _%>
 import <%= packageName %>.domain.enumeration.<%= fields[idx].fieldType %>
 <%_ } } _%>
@@ -102,7 +103,7 @@ _%>
 
     var <%= filterVariable.name %>: <%- filterVariable.filterType %>? = null<%= comma %>
 <%_ }) _%>
-) : Serializable {
+) : Serializable, Criteria {
 <%_ Object.keys(extraFilters).forEach((key) => {
         extraFilter = extraFilters[key]; _%>
     /**

--- a/generators/entity-server/templates/src/test/kotlin/package/web/rest/EntityResourceIT.kt.ejs
+++ b/generators/entity-server/templates/src/test/kotlin/package/web/rest/EntityResourceIT.kt.ejs
@@ -336,6 +336,69 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>: Ab
         verify(mock<%= entityClass %>SearchRepository, times(0)).save(<%= asEntity(entityInstance) %>)
         <%_ } _%>
     }
+
+    <%_ if (databaseType === 'sql' && isUsingMapsId === true) { _%>
+    @Test
+    @Transactional
+    @Throws(Exception::class)
+    fun update<%= entityClass %>MapsIdAssociationWithNewId() {
+        // Initialize the database
+<%_ if (service !== 'no' && dto !== 'mapstruct') { _%>
+        <%= entityInstance %>Service.save(<%= asEntity(entityInstance) %>)
+<%_ } else { _%>
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>)
+<%_ } _%>
+        <%_ const alreadyGeneratedEntities = []; _%>
+        val databaseSizeBeforeCreate = <%= entityInstance %>Repository.findAll().size
+
+        <%_ for (idx in relationships) {
+            const relationshipValidate = relationships[idx].relationshipValidate;
+            const otherEntityName = relationships[idx].otherEntityName;
+            const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
+            const mapsIdUse = relationships[idx].useJPADerivedIdentifier;
+            if (mapsIdUse === true) { _%>
+        // Add a new parent entity
+                <%_ if (alreadyGeneratedEntities.indexOf(otherEntityName) == -1) { _%>
+        val <%= otherEntityName %> = <%= otherEntityNameCapitalized %>ResourceIT.createEntity(em)
+        em.persist(<%= otherEntityName %>)
+        em.flush()
+                <%_ } _%>
+        <%_ alreadyGeneratedEntities.push(otherEntityName) _%>
+        <%_ } break; } _%>
+
+        // Load the <%= entityInstance %>
+        val updated<%= asEntity(entityClass) %> = <%= entityInstance %>Repository.findById(<%= asEntity(entityInstance) %>.id).get()<% if (databaseType === 'sql') { %>
+        // Disconnect from session so that the updates on updated<%= asEntity(entityClass) %> are not directly saved in db
+        em.detach(updated<%= asEntity(entityClass) %>)<% } %>
+
+        // Update the <%= mapsIdEntity %> with new association value
+        updated<%= asEntity(entityClass) %>.<%= mapsIdEntity %> = <%= alreadyGeneratedEntities.pop() %>
+        <%_ if (dto === 'mapstruct') { _%>
+        val updated<%= asDto(entityClass) %> = <%= entityInstance %>Mapper.toDto(updated<%= asEntity(entityClass) %>)
+        <%_ } _%>
+
+        // Update the entity
+        rest<%= entityClass %>MockMvc.perform(put("/api/<%= entityApiUrl %>")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(<%_ if (dto === 'mapstruct') { _%>updated<%= asDto(entityClass) %> <%_ } else { _%> updated<%= asEntity(entityClass) %> <%_ } _%>)))
+            .andExpect(status().isOk)
+
+        // Validate the <%= entityClass %> in the database
+        val <%= entityInstance %>List = <%= entityInstance %>Repository.findAll()
+        assertThat(<%= entityInstance %>List).hasSize(databaseSizeBeforeCreate)
+        val test<%= entityClass %> = <%= entityInstance %>List.get(<%= entityInstance %>List.size - 1)
+
+        // Validate the id for MapsId, the ids must be same
+        // Uncomment the following line for assertion. However, please note that there is a known issue and uncommenting will fail the test.
+        // Please look at https://github.com/jhipster/generator-jhipster/issues/9100. You can modify this test as necessary.
+        // assertThat(test<%= entityClass %>.id).isEqualTo(test<%= entityClass %>.get<%= mapsIdEntity %>().id)
+        <%_ if (searchEngine === 'elasticsearch') { _%>
+
+        // Validate the <%= entityClass %> in Elasticsearch
+        verify(mock<%= entityClass %>SearchRepository, times(0)).save(<%= asEntity(entityInstance) %>)
+        <%_ } _%>
+    }
+<%_ } _%>
 <% for (idx in fields) { %><% if (fields[idx].fieldValidate === true) {
     let required = false;
     if (fields[idx].fieldType !== 'byte[]' && fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) {

--- a/generators/entity-server/templates/src/test/kotlin/package/web/rest/EntityResourceIT.kt.ejs
+++ b/generators/entity-server/templates/src/test/kotlin/package/web/rest/EntityResourceIT.kt.ejs
@@ -300,7 +300,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>: Ab
         <%_ if (isUsingMapsId === true) { _%>
 
         // Validate the id for MapsId, the ids must be same
-        assertThat(test<%= entityClass %>.id).isEqualTo(test<%= entityClass %>.<%= mapsIdEntity %>().id)
+        assertThat(test<%= entityClass %>.id).isEqualTo(test<%= entityClass %>.<%= mapsIdEntityInstance %>?.id)
         <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
 
@@ -372,7 +372,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>: Ab
         em.detach(updated<%= asEntity(entityClass) %>)<% } %>
 
         // Update the <%= mapsIdEntity %> with new association value
-        updated<%= asEntity(entityClass) %>.<%= mapsIdEntity %> = <%= alreadyGeneratedEntities.pop() %>
+        updated<%= asEntity(entityClass) %>.<%= mapsIdEntityInstance %> = <%= alreadyGeneratedEntities.pop() %>
         <%_ if (dto === 'mapstruct') { _%>
         val updated<%= asDto(entityClass) %> = <%= entityInstance %>Mapper.toDto(updated<%= asEntity(entityClass) %>)
         <%_ } _%>
@@ -391,7 +391,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>: Ab
         // Validate the id for MapsId, the ids must be same
         // Uncomment the following line for assertion. However, please note that there is a known issue and uncommenting will fail the test.
         // Please look at https://github.com/jhipster/generator-jhipster/issues/9100. You can modify this test as necessary.
-        // assertThat(test<%= entityClass %>.id).isEqualTo(test<%= entityClass %>.get<%= mapsIdEntity %>().id)
+        // assertThat(test<%= entityClass %>.id).isEqualTo(test<%= entityClass %>.<%= mapsIdEntityInstance %>?.id)
         <%_ if (searchEngine === 'elasticsearch') { _%>
 
         // Validate the <%= entityClass %> in Elasticsearch

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1860,14 +1860,14 @@ function writeFiles() {
                                     <version>$\{hibernate.version}</version>
                                 </path>${
                                     this.authenticationType !== 'uaa'
-                                        ? `<path>
-                                    <groupId>javax.xml.bind</groupId>
-                                    <artifactId>jaxb-api</artifactId>
-                                    <version>$\{jaxb-api.version}</version>
+                                        ? `
+                                <path>
+                                    <groupId>org.glassfish.jaxb</groupId>
+                                    <artifactId>jaxb-runtime</artifactId>
+                                    <version>$\{jaxb-runtime.version}</version>
                                 </path>`
                                         : ''
-                                }
-                                    `
+                                }`
                                         : ''
                                 }
                             </annotationProcessorPaths>

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1858,17 +1858,16 @@ function writeFiles() {
                                     <groupId>org.hibernate</groupId>
                                     <artifactId>hibernate-jpamodelgen</artifactId>
                                     <version>$\{hibernate.version}</version>
-                                </path>
-                                <path>
+                                </path>${
+                                    this.authenticationType !== 'uaa'
+                                        ? `<path>
                                     <groupId>javax.xml.bind</groupId>
                                     <artifactId>jaxb-api</artifactId>
                                     <version>$\{jaxb-api.version}</version>
-                                </path>
-                                <path>
-                                    <groupId>com.sun.xml.bind</groupId>
-                                    <artifactId>jaxb-impl</artifactId>
-                                    <version>$\{jaxb-impl.version}</version>
                                 </path>`
+                                        : ''
+                                }
+                                    `
                                         : ''
                                 }
                             </annotationProcessorPaths>

--- a/generators/server/templates/gradle/kotlin.gradle.ejs
+++ b/generators/server/templates/gradle/kotlin.gradle.ejs
@@ -35,8 +35,9 @@ dependencies {
     kapt "org.mapstruct:mapstruct-processor:${mapstruct_version}"
     <%_ if (databaseType === 'sql') { _%>
     kapt "org.hibernate:hibernate-jpamodelgen:${hibernate_version}"
-    kapt "javax.xml.bind:jaxb-api:${jaxb_api_version}"
-    kapt "com.sun.xml.bind:jaxb-impl:${jaxb_impl_version}"
+        <%_ if (authenticationType !== 'uaa') { _%>
+    kapt "org.glassfish.jaxb:jaxb-runtime:${jaxb_runtime_version}"
+        <%_ } _%>
     <%_ } _%>
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"

--- a/generators/server/templates/src/main/kotlin/package/config/CacheConfiguration.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/config/CacheConfiguration.kt.ejs
@@ -133,7 +133,7 @@ import io.github.jhipster.config.JHipsterProperties
 <%_ } _%>
 class CacheConfiguration<%_ if (cacheProvider === 'ehcache') { _%>(jHipsterProperties: JHipsterProperties)<%_ } %><%_ if (cacheProvider === 'hazelcast') { %>(private val env: Environment<%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { %>,
     private val serverProperties: ServerProperties,
-    private val discoveryClient: DiscoveryClient)<%_ } } %><% if (cacheProvider === 'hazelcast') { %> : DisposableBean<% } %> {
+    private val discoveryClient: DiscoveryClient<%_ } } %>)<% if (cacheProvider === 'hazelcast') { %> : DisposableBean<% } %> {
     <%_ if (cacheProvider === 'ehcache') { _%>
 
     private val jcacheConfiguration: javax.cache.configuration.Configuration<Any, Any>
@@ -248,15 +248,15 @@ class CacheConfiguration<%_ if (cacheProvider === 'ehcache') { _%>(jHipsterPrope
         }
         <%_ } else { _%>
         config.networkConfig.port = 5701
-        config.networkConfig.portAutoIncrement = true
+        config.networkConfig.isPortAutoIncrement = true
 
         // In development, remove multicast auto-configuration
         if (env.acceptsProfiles(Profiles.of(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT))) {
             System.setProperty("hazelcast.local.localAddress", "127.0.0.1")
 
-            config.networkConfig.join.awsConfig.enabled = false
-            config.networkConfig.join.multicastConfig.enabled = false
-            config.networkConfig.join.tcpIpConfig.enabled = false
+            config.networkConfig.join.awsConfig.isEnabled = false
+            config.networkConfig.join.multicastConfig.isEnabled = false
+            config.networkConfig.join.tcpIpConfig.isEnabled = false
         }
         <%_ } _%>
         config.mapConfigs["default"] = initializeDefaultMapConfig(jHipsterProperties)

--- a/generators/server/templates/src/main/kotlin/package/config/CacheConfiguration.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/config/CacheConfiguration.kt.ejs
@@ -133,7 +133,7 @@ import io.github.jhipster.config.JHipsterProperties
 <%_ } _%>
 class CacheConfiguration<%_ if (cacheProvider === 'ehcache') { _%>(jHipsterProperties: JHipsterProperties)<%_ } %><%_ if (cacheProvider === 'hazelcast') { %>(private val env: Environment<%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { %>,
     private val serverProperties: ServerProperties,
-    private val discoveryClient: DiscoveryClient<%_ } } %>)<% if (cacheProvider === 'hazelcast') { %> : DisposableBean<% } %> {
+    private val discoveryClient: DiscoveryClient<%_ } %>)<% } %><% if (cacheProvider === 'hazelcast') { %> : DisposableBean<% } %> {
     <%_ if (cacheProvider === 'ehcache') { _%>
 
     private val jcacheConfiguration: javax.cache.configuration.Configuration<Any, Any>

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.0.tgz",
-            "integrity": "sha512-Lg00egj78gM+4aE0Erw05cuDbvX9sLJbaaPwwRtdCdAMnIudqrQZ0oZX98Ek0yiSK/A2nubHgJfvII/rTT2Dwg=="
+            "version": "11.13.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+            "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
         },
         "acorn": {
             "version": "6.1.1",
@@ -872,9 +872,9 @@
             }
         },
         "conf": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/conf/-/conf-2.0.0.tgz",
-            "integrity": "sha512-iCLzBsGFi8S73EANsEJZz0JnJ/e5VZef/kSaxydYZLAvw0rFNAUx5R7K5leC/CXXR2mZfXWhUvcZOO/dM2D5xg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/conf/-/conf-2.2.0.tgz",
+            "integrity": "sha512-93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==",
             "requires": {
                 "dot-prop": "^4.1.0",
                 "env-paths": "^1.0.0",
@@ -900,11 +900,13 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "requires": {
-                "lru-cache": "^4.0.1",
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
             }
@@ -1261,7 +1263,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -1398,19 +1399,6 @@
                     "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
                     "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
                     "dev": true
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
                 },
                 "debug": {
                     "version": "4.1.1",
@@ -1741,12 +1729,12 @@
             "dev": true
         },
         "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
                 "is-stream": "^1.1.0",
                 "npm-run-path": "^2.0.0",
                 "p-finally": "^1.0.0",
@@ -1904,6 +1892,11 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "faker": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+            "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
         },
         "fast-deep-equal": {
             "version": "2.0.1",
@@ -2161,246 +2154,38 @@
             }
         },
         "generator-jhipster": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-5.8.2.tgz",
-            "integrity": "sha512-GW33cKnIf0wWuK411U9GDiNKwKVLbL4BpAqyR4b9JD6ClhwHsQg3HRlItN8pV0iTHJtyFnSfcV/9nJIHFWwvKA==",
+            "version": "6.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-6.0.0-beta.0.tgz",
+            "integrity": "sha512-VQT/aRw/BCX+4Z1ASJQ2RyI439hy/yZg9aVU99r3Q6cXY5ZqOd+fVo8zXWEDR5mmbQChbZs7dGGtRdPLXFlsgQ==",
             "requires": {
                 "axios": "0.18.0",
-                "chalk": "2.4.1",
-                "commander": "2.16.0",
-                "conf": "2.0.0",
+                "chalk": "2.4.2",
+                "commander": "2.19.0",
+                "conf": "2.2.0",
                 "didyoumean": "1.2.1",
                 "ejs": "2.6.1",
-                "glob": "7.1.2",
+                "faker": "4.1.0",
+                "glob": "7.1.3",
                 "gulp-filter": "5.1.0",
                 "insight": "0.10.1",
-                "jhipster-core": "3.6.11",
+                "jhipster-core": "3.6.13",
                 "js-object-pretty-print": "0.3.0",
-                "js-yaml": "3.12.0",
-                "lodash": "4.17.10",
+                "js-yaml": "3.12.2",
+                "lodash": "4.17.11",
                 "meow": "5.0.0",
                 "mkdirp": "0.5.1",
-                "os-locale": "2.1.0",
+                "os-locale": "3.1.0",
                 "parse-gitignore": "1.0.1",
                 "pluralize": "7.0.0",
-                "prettier": "1.13.7",
-                "randexp": "0.4.9",
-                "semver": "5.5.0",
-                "shelljs": "0.8.2",
+                "prettier": "1.16.4",
+                "randexp": "0.5.3",
+                "semver": "5.6.0",
+                "shelljs": "0.8.3",
                 "tabtab": "2.2.2",
-                "through2": "2.0.3",
+                "through2": "3.0.1",
                 "uuid": "3.3.2",
-                "yeoman-environment": "2.3.0",
-                "yeoman-generator": "3.0.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "commander": {
-                    "version": "2.16.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-                    "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "jhipster-core": {
-                    "version": "3.6.11",
-                    "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.6.11.tgz",
-                    "integrity": "sha512-OibJay1+nwKk+mfRfuTrt2rW2h7BmGNfKWR7TQO4oYqG+I096EvJxZkIMCcjA9KuKLOZvnzfEi4UbtKyRTmHkg==",
-                    "requires": {
-                        "chevrotain": "4.2.0",
-                        "fs-extra": "7.0.1",
-                        "lodash": "4.17.11",
-                        "winston": "3.2.1"
-                    },
-                    "dependencies": {
-                        "lodash": {
-                            "version": "4.17.11",
-                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-                            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-                        }
-                    }
-                },
-                "js-yaml": {
-                    "version": "3.12.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-                    "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-                    "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "lodash": {
-                    "version": "4.17.10",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                },
-                "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-                    "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
-                },
-                "prettier": {
-                    "version": "1.13.7",
-                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
-                    "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w=="
-                },
-                "randexp": {
-                    "version": "0.4.9",
-                    "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
-                    "integrity": "sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
-                    "requires": {
-                        "drange": "^1.0.0",
-                        "ret": "^0.2.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-                    "requires": {
-                        "find-up": "^3.0.0",
-                        "read-pkg": "^3.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-                },
-                "shelljs": {
-                    "version": "0.8.2",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-                    "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-                    "requires": {
-                        "glob": "^7.0.0",
-                        "interpret": "^1.0.0",
-                        "rechoir": "^0.6.2"
-                    }
-                },
-                "yeoman-environment": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.0.tgz",
-                    "integrity": "sha512-PHSAkVOqYdcR+C+Uht1SGC4eVD/9OhygYFkYaI66xF8vKIeS1RNYay+umj2ZrQeJ50tF5Q/RSO6qGDz9y3Ifug==",
-                    "requires": {
-                        "chalk": "^2.1.0",
-                        "cross-spawn": "^6.0.5",
-                        "debug": "^3.1.0",
-                        "diff": "^3.3.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "globby": "^8.0.1",
-                        "grouped-queue": "^0.3.3",
-                        "inquirer": "^5.2.0",
-                        "is-scoped": "^1.0.0",
-                        "lodash": "^4.17.10",
-                        "log-symbols": "^2.1.0",
-                        "mem-fs": "^1.1.0",
-                        "strip-ansi": "^4.0.0",
-                        "text-table": "^0.2.0",
-                        "untildify": "^3.0.2"
-                    }
-                },
-                "yeoman-generator": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-3.0.0.tgz",
-                    "integrity": "sha512-aHsNXzkdgAoakZTZsDX7T56wYWYd1O5E/GBIFAVMJLH7TKRr+1MiEJszZQbbCSA+J+lpT743/8L88j35yNdTLQ==",
-                    "requires": {
-                        "async": "^2.6.0",
-                        "chalk": "^2.3.0",
-                        "cli-table": "^0.3.1",
-                        "cross-spawn": "^6.0.5",
-                        "dargs": "^6.0.0",
-                        "dateformat": "^3.0.3",
-                        "debug": "^3.1.0",
-                        "detect-conflict": "^1.0.0",
-                        "error": "^7.0.2",
-                        "find-up": "^3.0.0",
-                        "github-username": "^4.0.0",
-                        "istextorbinary": "^2.2.1",
-                        "lodash": "^4.17.10",
-                        "make-dir": "^1.1.0",
-                        "mem-fs-editor": "^5.0.0",
-                        "minimist": "^1.2.0",
-                        "pretty-bytes": "^5.1.0",
-                        "read-chunk": "^2.1.0",
-                        "read-pkg-up": "^4.0.0",
-                        "rimraf": "^2.6.2",
-                        "run-async": "^2.0.0",
-                        "shelljs": "^0.8.0",
-                        "text-table": "^0.2.0",
-                        "through2": "^2.0.0",
-                        "yeoman-environment": "^2.0.5"
-                    }
-                }
+                "yeoman-environment": "2.3.4",
+                "yeoman-generator": "3.2.0"
             }
         },
         "get-caller-file": {
@@ -2422,9 +2207,12 @@
             "dev": true
         },
         "get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-value": {
             "version": "2.0.6",
@@ -2556,6 +2344,13 @@
                 "timed-out": "^4.0.0",
                 "url-parse-lax": "^1.0.0",
                 "url-to-options": "^1.0.1"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                }
             }
         },
         "graceful-fs": {
@@ -2835,9 +2630,9 @@
             "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
         },
         "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -3082,9 +2877,9 @@
             }
         },
         "jhipster-core": {
-            "version": "3.6.12",
-            "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.6.12.tgz",
-            "integrity": "sha512-QDotKNPKyjJZN8iGDTPX/C2q/J++dQm2CbH9pgJoxy3gv23Scu9egHuuG/ZkDZHabtOofEVhPVaUcE6ieCOpnQ==",
+            "version": "3.6.13",
+            "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-3.6.13.tgz",
+            "integrity": "sha512-o3AeTApDK8fLVSbDrzNipTE2Q6CqitIElTrpxIK2vsxzQhGwx4rC+3/Svg+4Kc2sjQZM2TIk97N68Hu8oQkDKA==",
             "requires": {
                 "chevrotain": "4.2.0",
                 "fs-extra": "7.0.1",
@@ -3182,11 +2977,11 @@
             }
         },
         "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "^2.0.0"
             }
         },
         "levn": {
@@ -3300,15 +3095,6 @@
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
             "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
-        "lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
         "macos-release": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
@@ -3326,7 +3112,6 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
             "requires": {
                 "p-defer": "^1.0.0"
             }
@@ -3350,11 +3135,20 @@
             }
         },
         "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+                }
             }
         },
         "mem-fs": {
@@ -3365,6 +3159,39 @@
                 "through2": "^2.0.0",
                 "vinyl": "^1.1.0",
                 "vinyl-file": "^2.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "mem-fs-editor": {
@@ -3395,10 +3222,41 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
                 "replace-ext": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
                     "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "2.2.0",
@@ -3589,9 +3447,9 @@
             },
             "dependencies": {
                 "camelcase": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-                    "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                     "dev": true
                 },
                 "cliui": {
@@ -3605,34 +3463,6 @@
                         "wrap-ansi": "^2.0.0"
                     }
                 },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "execa": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^4.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -3641,21 +3471,6 @@
                     "requires": {
                         "locate-path": "^3.0.0"
                     }
-                },
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
-                "invert-kv": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-                    "dev": true
                 },
                 "js-yaml": {
                     "version": "3.12.0",
@@ -3667,15 +3482,6 @@
                         "esprima": "^4.0.0"
                     }
                 },
-                "lcid": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-                    "dev": true,
-                    "requires": {
-                        "invert-kv": "^2.0.0"
-                    }
-                },
                 "locate-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -3684,34 +3490,6 @@
                     "requires": {
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
-                    }
-                },
-                "mem": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-                    "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
-                    "dev": true,
-                    "requires": {
-                        "map-age-cleaner": "^0.1.1",
-                        "mimic-fn": "^2.0.0",
-                        "p-is-promise": "^2.0.0"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-                    "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
-                    "dev": true
-                },
-                "os-locale": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-                    "dev": true,
-                    "requires": {
-                        "execa": "^1.0.0",
-                        "lcid": "^2.0.0",
-                        "mem": "^4.0.0"
                     }
                 },
                 "p-limit": {
@@ -3733,9 +3511,9 @@
                     }
                 },
                 "p-try": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-                    "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 },
                 "supports-color": {
@@ -4070,13 +3848,13 @@
             }
         },
         "os-locale": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
             "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
             }
         },
         "os-name": {
@@ -4106,8 +3884,7 @@
         "p-defer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
         },
         "p-finally": {
             "version": "1.0.0",
@@ -4117,8 +3894,7 @@
         "p-is-promise": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-            "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
-            "dev": true
+            "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
         },
         "p-limit": {
             "version": "1.3.0",
@@ -4356,11 +4132,6 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
         "psl": {
             "version": "1.1.31",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -4370,7 +4141,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -4401,12 +4171,19 @@
             }
         },
         "read-chunk": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-            "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
+            "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
             "requires": {
-                "pify": "^3.0.0",
-                "safe-buffer": "^5.1.1"
+                "pify": "^4.0.1",
+                "with-open-file": "^0.1.6"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+                }
             }
         },
         "read-input": {
@@ -4435,9 +4212,9 @@
             }
         },
         "readable-stream": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-            "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+            "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
             "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -5387,36 +5164,11 @@
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+            "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
+                "readable-stream": "2 || 3"
             }
         },
         "timed-out": {
@@ -5818,9 +5570,9 @@
             },
             "dependencies": {
                 "p-try": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-                    "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
                 },
                 "pify": {
                     "version": "4.0.1",
@@ -5917,11 +5669,6 @@
             "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
             "dev": true
         },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
         "yargs": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
@@ -5965,6 +5712,12 @@
                         "pinkie-promise": "^2.0.0"
                     }
                 },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                    "dev": true
+                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5972,6 +5725,15 @@
                     "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
+                    }
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -6112,9 +5874,9 @@
             },
             "dependencies": {
                 "camelcase": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-                    "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                     "dev": true
                 },
                 "cliui": {
@@ -6128,34 +5890,6 @@
                         "wrap-ansi": "^2.0.0"
                     }
                 },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "execa": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^4.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -6163,30 +5897,6 @@
                     "dev": true,
                     "requires": {
                         "locate-path": "^3.0.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
-                "invert-kv": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-                    "dev": true
-                },
-                "lcid": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-                    "dev": true,
-                    "requires": {
-                        "invert-kv": "^2.0.0"
                     }
                 },
                 "locate-path": {
@@ -6197,34 +5907,6 @@
                     "requires": {
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
-                    }
-                },
-                "mem": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-                    "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
-                    "dev": true,
-                    "requires": {
-                        "map-age-cleaner": "^0.1.1",
-                        "mimic-fn": "^2.0.0",
-                        "p-is-promise": "^2.0.0"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-                    "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
-                    "dev": true
-                },
-                "os-locale": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-                    "dev": true,
-                    "requires": {
-                        "execa": "^1.0.0",
-                        "lcid": "^2.0.0",
-                        "mem": "^4.0.0"
                     }
                 },
                 "p-limit": {
@@ -6246,9 +5928,9 @@
                     }
                 },
                 "p-try": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-                    "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 },
                 "which-module": {
@@ -6326,18 +6008,6 @@
                     "version": "0.7.0",
                     "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
                     "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
                 },
                 "external-editor": {
                     "version": "3.0.3",
@@ -6421,18 +6091,6 @@
                 "yeoman-environment": "^2.0.5"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6480,23 +6138,9 @@
                     }
                 },
                 "p-try": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-                    "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
-                },
-                "pify": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-                },
-                "read-chunk": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.1.0.tgz",
-                    "integrity": "sha512-ZdiZJXXoZYE08SzZvTipHhI+ZW0FpzxmFtLI3vIeMuRN9ySbIZ+SZawKogqJ7dxW9fJ/W73BNtxu4Zu/bZp+Ng==",
-                    "requires": {
-                        "pify": "^4.0.1",
-                        "with-open-file": "^0.1.5"
-                    }
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
                 },
                 "read-pkg-up": {
                     "version": "4.0.0",
@@ -6505,14 +6149,6 @@
                     "requires": {
                         "find-up": "^3.0.0",
                         "read-pkg": "^3.0.0"
-                    }
-                },
-                "through2": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-                    "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-                    "requires": {
-                        "readable-stream": "2 || 3"
                     }
                 }
             }
@@ -6544,19 +6180,6 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
                 },
                 "dargs": {
                     "version": "5.1.0",
@@ -6609,11 +6232,55 @@
                     "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
                     "dev": true
                 },
+                "read-chunk": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+                    "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0",
+                        "safe-buffer": "^5.1.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
                 "replace-ext": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
                     "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
                     "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "commander": "2.19.0",
         "didyoumean": "1.2.1",
         "ejs": "2.6.1",
-        "generator-jhipster": "5.8.2",
+        "generator-jhipster": "6.0.0-beta.0",
         "glob": "7.1.3",
         "insight": "0.10.1",
         "jhipster-core": "3.6.13",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "generator-jhipster": "5.8.2",
         "glob": "7.1.3",
         "insight": "0.10.1",
-        "jhipster-core": "3.6.12",
+        "jhipster-core": "3.6.13",
         "js-yaml": "3.12.2",
         "lodash": "4.17.11",
         "meow": "5.0.0",


### PR DESCRIPTION
This PR updates to latest JHipster  6.0.0 beta.0 and contains the following changes:

- Update to JHipster generator 6.0.0-beta.0 
- Update to JHipster Core 3.6.13 
- Add automated travis test for `@MapsId` (https://github.com/jhipster/generator-jhipster/pull/9094) + fix issues with usage of `@MapsId`
- Criteria copy method and constructor (https://github.com/jhipster/generator-jhipster/pull/#9363)
- CI: allow config with Yarn (https://github.com/jhipster/generator-jhipster/pull/#9497)
- CI: update JDK8 / JDK11 builds (https://github.com/jhipster/generator-jhipster/pull/9512)
- Change to jaxb-runtime and explicitly include it when using UAA (https://github.com/jhipster/generator-jhipster/pull/9516)
- Use SDKMan to provision Open JDK 11(https://github.com/jhipster/generator-jhipster/pull/9518)
- Fixes for `CacheConfiguration`

**NOTE:** Also includes change made in #106 although not rebased from that branch