### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This project adds Kotlin to the JHipster application 😎. It is based on JHipst
 ## 🚀 How to get started
 
 Install the package with `npm install -g generator-jhipster-kotlin`
-
-1. Install the package with `npm install -g generator-jhipster-kotlin`
-2. Generate the application with `khipster`
+1. Make sure you have `yo` installed with `npm install -g yo`
+2. Install the package with `npm install -g generator-jhipster-kotlin`
+3. Generate the application with `khipster`
 
 (or)
 


### PR DESCRIPTION
pointing out that `yo` must be installed in order to use `khipster`