### PR TITLE
replace hard-coded value of `test@localhost` with property value

### DIFF
--- a/generators/server/templates/src/test/kotlin/package/service/MailServiceIT.kt.ejs
+++ b/generators/server/templates/src/test/kotlin/package/service/MailServiceIT.kt.ejs
@@ -87,7 +87,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         val message = messageCaptor.value
         assertThat(message.subject).isEqualTo("testSubject")
         assertThat(message.allRecipients[0].toString()).isEqualTo("john.doe@example.com")
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content).isInstanceOf(String::class.java)
         assertThat(message.content.toString()).isEqualTo("testContent")
         assertThat(message.dataHandler.contentType).isEqualTo("text/plain; charset=UTF-8")
@@ -101,7 +101,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         val message = messageCaptor.value
         assertThat(message.subject).isEqualTo("testSubject")
         assertThat(message.allRecipients[0].toString()).isEqualTo("john.doe@example.com")
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content).isInstanceOf(String::class.java)
         assertThat(message.content.toString()).isEqualTo("testContent")
         assertThat(message.dataHandler.contentType).isEqualTo("text/html;charset=UTF-8")
@@ -119,7 +119,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         part.writeTo(aos)
         assertThat(message.subject).isEqualTo("testSubject")
         assertThat(message.allRecipients[0].toString()).isEqualTo("john.doe@example.com")
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content).isInstanceOf(Multipart::class.java)
         assertThat(aos.toString()).isEqualTo("\r\ntestContent")
         assertThat(part.dataHandler.contentType).isEqualTo("text/plain; charset=UTF-8")
@@ -137,7 +137,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         part.writeTo(aos)
         assertThat(message.subject).isEqualTo("testSubject")
         assertThat(message.allRecipients[0].toString()).isEqualTo("john.doe@example.com")
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content).isInstanceOf(Multipart::class.java)
         assertThat(aos.toString()).isEqualTo("\r\ntestContent")
         assertThat(part.dataHandler.contentType).isEqualTo("text/html;charset=UTF-8")
@@ -156,7 +156,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         val message = messageCaptor.value
         assertThat(message.subject).isEqualTo("test title")
         assertThat(message.allRecipients[0].toString()).isEqualTo(user.email)
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content.toString()).isEqualToNormalizingNewlines("<html>test title, http://127.0.0.1:8080, john</html>\n")
         assertThat(message.dataHandler.contentType).isEqualTo("text/html;charset=UTF-8")
     }
@@ -174,7 +174,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         verify<JavaMailSenderImpl>(javaMailSender).send(messageCaptor.capture())
         val message = messageCaptor.value
         assertThat(message.allRecipients[0].toString()).isEqualTo(user.email)
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content.toString()).isNotEmpty()
         assertThat(message.dataHandler.contentType).isEqualTo("text/html;charset=UTF-8")
     }
@@ -191,7 +191,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         verify<JavaMailSenderImpl>(javaMailSender).send(messageCaptor.capture())
         val message = messageCaptor.value
         assertThat(message.allRecipients[0].toString()).isEqualTo(user.email)
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content.toString()).isNotEmpty()
         assertThat(message.dataHandler.contentType).isEqualTo("text/html;charset=UTF-8")
     }
@@ -208,7 +208,7 @@ class MailServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
         verify<JavaMailSenderImpl>(javaMailSender).send(messageCaptor.capture())
         val message = messageCaptor.value
         assertThat(message.allRecipients[0].toString()).isEqualTo(user.email)
-        assertThat(message.from[0].toString()).isEqualTo("test@localhost")
+        assertThat(message.from[0].toString()).isEqualTo(jHipsterProperties.mail.from)
         assertThat(message.content.toString()).isNotEmpty()
         assertThat(message.dataHandler.contentType).isEqualTo("text/html;charset=UTF-8")
     }


### PR DESCRIPTION
In the `MailServiceIT.kt.ejs` the value of sender is hard-coded. This value is, by default, the same one as given in the `application.yml` file under the key `jhipster.mail.from`. In the case we change the `test@localhost` value in the `application.yml` file, the tests will fail. This change will make tests pass in this case without having to do anything further.