### PR TITLE
Add @file:JvmName to utility files

### DIFF
--- a/generators/server/templates/src/main/kotlin/package/config/DefaultProfileUtil.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/config/DefaultProfileUtil.kt.ejs
@@ -16,6 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+@file:JvmName("DefaultProfileUtil")
+
 package <%=packageName%>.config
 
 import io.github.jhipster.config.JHipsterConstants

--- a/generators/server/templates/src/main/kotlin/package/security/SecurityUtils.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/security/SecurityUtils.kt.ejs
@@ -16,6 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+@file:JvmName("SecurityUtils")
+
 package <%=packageName%>.security
 
 <%_ if (reactive) { _%>

--- a/generators/server/templates/src/main/kotlin/package/service/util/RandomUtil.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/service/util/RandomUtil.kt.ejs
@@ -16,6 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+@file:JvmName("RandomUtil")
+
 package <%=packageName%>.service.util
 
 import org.apache.commons.lang3.RandomStringUtils

--- a/generators/server/templates/src/test/kotlin/package/web/rest/TestUtil.kt.ejs
+++ b/generators/server/templates/src/test/kotlin/package/web/rest/TestUtil.kt.ejs
@@ -16,6 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+@file:JvmName("TestUtil")
+
 package <%=packageName%>.web.rest
 
 import com.fasterxml.jackson.annotation.JsonInclude


### PR DESCRIPTION
Added @file:JvmName to utility classes.

Allows smoother Java interoperability, no longer requiring the use of the `Kt` suffix when accessing such classes 