### PR TITLE
set JVM target to '1.8' for task 'compileTestKotlin'

### DIFF
--- a/generators/server/templates/gradle/kotlin.gradle.ejs
+++ b/generators/server/templates/gradle/kotlin.gradle.ejs
@@ -51,7 +51,7 @@ allOpen {
     annotation("javax.persistence.Embeddable")
 }<%_ } %>
 
-compileKotlin {
+[compileKotlin, compileTestKotlin]*.with {
     kotlinOptions {
     	jvmTarget = "<%= JAVA_VERSION %>"
         javaParameters = true<%_ if (databaseType === 'couchbase') { %>


### PR DESCRIPTION
If only `compileKotlin` is configured for target `1.8`, then `compileTestKotlin` defaults to target `1.6`. This can have strange side effects like the compiler complaining "Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6". This happens for example with the JUnit Jupiter AssertionsKT like `assertThrows<SomeException> {}`.