### PR TITLE
Fix Integration tests not compiling and generating Java

### DIFF
--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -124,12 +124,12 @@ module.exports = class extends BaseGenerator {
 
                 this.mappingImports = this.usedMethods.map(method => `org.springframework.web.bind.annotation.${method}Mapping`);
                 this.mockRequestImports = this.usedMethods.map(
-                    method => `static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.${method.toLowerCase()}`
+                    method => `org.springframework.test.web.servlet.request.MockMvcRequestBuilders.${method.toLowerCase()}`
                 );
 
                 this.mockRequestImports =
                     this.mockRequestImports.length > 3
-                        ? ['static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*']
+                        ? ['org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*']
                         : this.mockRequestImports;
 
                 this.mainClass = this.getMainClassName();

--- a/generators/spring-controller/templates/src/test/kotlin/package/web/rest/ResourceIT.kt.ejs
+++ b/generators/spring-controller/templates/src/test/kotlin/package/web/rest/ResourceIT.kt.ejs
@@ -35,7 +35,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
  *
  * @see <%= controllerClass %>
  */
-@SpringBootTest(classes = <%= mainClass %>.class)
+@SpringBootTest(classes = [<%= mainClass %>::class])
 class <%= controllerClass %>IT {
 
     private lateinit var restMockMvc: MockMvc
@@ -44,7 +44,7 @@ class <%= controllerClass %>IT {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
 
-        <%= controllerClass %> <%= controllerInstance %> = new <%= controllerClass %>()
+        val <%= controllerInstance %> = <%= controllerClass %>()
         restMockMvc = MockMvcBuilders
             .standaloneSetup(<%= controllerInstance %>)
             .build()


### PR DESCRIPTION
The integration tests for the controller/resources are generating Java code instead of Kotlin.
This causes them not to compile and fail.
