### PR TITLE
Fix Jwts usage to get rid of the deprecation warning

### DIFF
--- a/generators/server/templates/src/main/kotlin/package/security/jwt/TokenProvider.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/security/jwt/TokenProvider.kt.ejs
@@ -89,8 +89,9 @@ class TokenProvider(private val jHipsterProperties: JHipsterProperties) {
     }
 
     fun getAuthentication(token: String): Authentication {
-        val claims = Jwts.parser()
+        val claims = Jwts.parserBuilder()
             .setSigningKey(key)
+            .build()
             .parseClaimsJws(token)
             .body
 
@@ -104,7 +105,11 @@ class TokenProvider(private val jHipsterProperties: JHipsterProperties) {
 
     fun validateToken(authToken: String): Boolean {
         try {
-            Jwts.parser().setSigningKey(key).parseClaimsJws(authToken)
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(authToken)
+
             return true
         } catch (e: JwtException) {
             log.info("Invalid JWT token.")


### PR DESCRIPTION
jjwt project has deprecated the `Jwts.parser()` method in favor of `Jwts.parserBuilder()` some months ago. This patch corrects the relevant code to use the updated versions and avoids the deprecation warning. 

More info: [https://github.com/jwtk/jjwt/pull/499](https://github.com/jwtk/jjwt/pull/499)