### PR TITLE
Added missing brackets when generating User.kt

### DIFF
--- a/generators/server/templates/src/main/kotlin/package/domain/User.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/domain/User.kt.ejs
@@ -171,7 +171,7 @@ class <%= asEntity('User') %> (
     <%_ } _%>
     var id: String? = null,
 <%_ } _%>
-    
+
     @field:NotNull
     @field:Pattern(regexp = LOGIN_REGEX)
     @field:Size(min = 1, max = 50)
@@ -360,7 +360,7 @@ class <%= asEntity('User') %> (
     <%_ if (authenticationType === 'session' && databaseType === 'sql' && !reactive) { _%>
 
     @JsonIgnore
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "user")
+    @OneToMany(cascade = [ CascadeType.ALL ], orphanRemoval = true, mappedBy = "user")
     <%_ if (enableHibernateCache) { _%>
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     <%_ } _%>


### PR DESCRIPTION
The **cascade** parameter in @OneToMany annotation is an array of **CascadeType**. Previously, it was set to a single value without brackets `cascade = CascadeType.ALL`, it will lead to compilation errors. This PR will surround the CascadeType.ALL with brackets in order to remove the compilation errors within Kotlin.

[Link to issue](https://github.com/jhipster/jhipster-kotlin/issues/240)