### PR TITLE
Remove side affect of mock DateTimeProvider

### DIFF
--- a/generators/server/templates/src/test/kotlin/package/service/UserServiceIT.kt.ejs
+++ b/generators/server/templates/src/test/kotlin/package/service/UserServiceIT.kt.ejs
@@ -69,12 +69,10 @@ import org.junit.jupiter.api.extension.ExtendWith
 <%_ if (databaseType === 'neo4j') { _%>
 import org.junit.jupiter.api.extension.ExtendWith
 <%_ } _%>
-<%_ if (databaseType === 'sql' && !reactive && authenticationType !== 'oauth2') { _%>
-import org.mockito.Mock
-<%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 <%_ if (databaseType === 'sql' && !reactive && authenticationType !== 'oauth2') { _%>
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.auditing.AuditingHandler
 import org.springframework.data.auditing.DateTimeProvider
 <%_ } _%>

--- a/generators/server/templates/src/test/kotlin/package/service/UserServiceIT.kt.ejs
+++ b/generators/server/templates/src/test/kotlin/package/service/UserServiceIT.kt.ejs
@@ -194,7 +194,7 @@ class UserServiceIT <% if (databaseType === 'cassandra') { %>: AbstractCassandra
     @Autowired
     private lateinit var auditingHandler: AuditingHandler
 
-    @Mock
+    @MockBean
     private lateinit var dateTimeProvider: DateTimeProvider
     <%_ } _%>
     <%_ if (databaseType !== 'no') { _%>


### PR DESCRIPTION
Using mock for dateTimeProvider may affect users test that use dateTimeProvider. To avoid side affect we need to use @MockBean

[Link to issue](https://github.com/jhipster/jhipster-kotlin/issues/246)