### PR TITLE
feat: build and run from Docker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,41 @@ Install the package with `npm install -g generator-jhipster-kotlin`
 2. Install the package with `npm install -g generator-jhipster-kotlin`
 3. Generate the application with `khipster`
 
+## Using Docker
+
+Download the Dockerfile:
+
+```bash
+mkdir docker
+cd docker
+wget https://github.com/jhipster/jhipster-kotlin/raw/main/docker/Dockerfile
+```
+
+Build the Docker images:
+
+```bash
+docker build -t jhipster-generator-kotlin:latest .
+```
+
+Make a folder where you want to generate the Service:
+
+```bash
+mkdir service
+cd service
+```
+
+Run the generator from image to generate service:
+
+```bash
+docker run -it --rm -v $PWD:/home/khipster/app jhipster-generator-kotlin
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/khipster/app jhipster-generator-kotlin /bin/bash
+```
+
 ## 🚦 What we have now
 
 ✅ General App generation - `khipster`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:20.04
+RUN \
+  # configure the "khipster" user
+  groupadd khipster && \
+  useradd khipster -s /bin/bash -m -g khipster -G sudo && \
+  echo 'khipster:khipster' |chpasswd && \
+  mkdir /home/khipster/app && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  export TZ=Europe\Paris && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+  apt-get update && \
+  # install utilities
+  apt-get install -y \
+    wget \
+    sudo && \
+  # install node.js
+  wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
+  tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
+  # upgrade npm
+  npm install -g npm && \
+  # install yeoman
+  npm install -g yo && \
+  # cleanup
+  apt-get clean && \
+  rm -rf \
+    /home/khipster/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+RUN \
+  # install the blueprint
+  npm install -g generator-jhipster-kotlin && \
+  # fix khipster user permissions
+  chown -R khipster:khipster \
+    /home/khipster \
+    /usr/local/lib/node_modules && \
+  # cleanup
+  rm -rf \
+    /home/khipster/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# expose the working directory
+USER khipster
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/khipster/app"
+VOLUME ["/home/khipster/app"]
+CMD khipster


### PR DESCRIPTION
Build and run the generator from docker image support added.

The main aim and motivation behind doing this is, because
of a no. of different jhipster blueprints are there,
which are compatible and works with the different version of jhipster
and also might be incompatible with other blueprints or versions of jhipster.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>