### PR TITLE
Add badge for Azure Pipelines + Microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Full documentation and information about JHipster is available [here](https://ww
 
 ![Webflux](https://github.com/jhipster/jhipster-kotlin/workflows/Webflux/badge.svg)
 
+![Microservices](https://dev.azure.com/jhipster/jhipster-kotlin/_apis/build/status/jhipster.jhipster-kotlin?branchName=main)
+
 ![KHipster Generated Applications CI](https://github.com/jhipster/jhipster-kotlin/workflows/KHipster%20Generated%20Applications%20CI/badge.svg)
 
 # Greetings, Kotlin Hipster!


### PR DESCRIPTION
related to https://github.com/jhipster/generator-jhipster/issues/11935
I configured Azure Devops, to use `main` branch, so I added the badge here
