### PR TITLE
fix: remove generating patch method for read-only entities

### DIFF
--- a/generators/entity-server/templates/src/main/kotlin/package/web/rest/EntityResource.kt.ejs
+++ b/generators/entity-server/templates/src/main/kotlin/package/web/rest/EntityResource.kt.ejs
@@ -274,7 +274,6 @@ _%><%- include('../../common/inject_template', {viaService: viaService, construc
             .body(result)
         <%_ } _%>
     }
-<%_ } _%>
 
     /**
     * {@code PATCH  /<%= entityApiUrl %>/:<%= primaryKey.name %>} : Partial updates given fields of an existing <%= entityInstance %>, field will ignore if it is null
@@ -344,7 +343,7 @@ _%><%- include('../../common/inject_template', {viaService: viaService, construc
         )
             <%_ } _%>
     }
-
+    <%_ } _%>
     /**
      * `GET  /<%= entityApiUrl %>` : get all the <%= entityInstancePlural %>.
      *


### PR DESCRIPTION
Closes #339 