### PR TITLE
Fix extract principal security utils

### DIFF
--- a/generators/server/templates/src/main/kotlin/package/security/SecurityUtils.kt.ejs
+++ b/generators/server/templates/src/main/kotlin/package/security/SecurityUtils.kt.ejs
@@ -79,12 +79,15 @@ fun extractPrincipal(authentication: Authentication?): String? {
 
     if(authentication == null) {
         return null
+    <%_ if (authenticationTypeOauth2) { _%>
+    } else if (authentication is JwtAuthenticationToken) {
+        return authentication.token.claims["preferred_username"].toString()
+    <%_ } _%>
     }
 
     return when (val principal = authentication.principal) {
         is UserDetails -> principal.username
         <%_ if (authenticationTypeOauth2) { _%>
-        is JwtAuthenticationToken -> (authentication as JwtAuthenticationToken).token.claims as String
         is DefaultOidcUser -> {
             if(principal.attributes.containsKey("preferred_username")) {
                 principal.attributes["preferred_username"].toString()
@@ -157,7 +160,7 @@ fun hasCurrentUserAnyOfAuthorities(vararg authorities: String): <% if (reactive)
 return ReactiveSecurityContextHolder.getContext()
     .map(SecurityContext::getAuthentication)
     .map(Authentication::getAuthorities)
-    .map { 
+    .map {
         it
         .map(GrantedAuthority::getAuthority)
         .any { authorities.contains(it) }
@@ -176,7 +179,7 @@ return authentication != null && getAuthorities(authentication)?.any { authoriti
 */
 fun hasCurrentUserNoneOfAuthorities(vararg authorities: String): <% if (reactive) { %>Mono<Boolean><% } else { %>Boolean<% } %> {
 <%_ if (reactive) { _%>
-    return hasCurrentUserAnyOfAuthorities(*authorities).map { !it } 
+    return hasCurrentUserAnyOfAuthorities(*authorities).map { !it }
 <%_ } else { _%>
     return !hasCurrentUserAnyOfAuthorities(*authorities)
 <%_ } _%>
@@ -210,7 +213,7 @@ fun getAuthorities(authentication: Authentication): List<String>? {
 <%_ } _%>
 
 <%_ if (authenticationTypeOauth2) { _%>
-    fun extractAuthorityFromClaims(claims: Map<String, Any>): List<GrantedAuthority>? {
+    fun extractAuthorityFromClaims(claims: Map<String, Any>): List<GrantedAuthority> {
         return mapRolesToGrantedAuthorities(getRolesFromClaims(claims))
     }
 


### PR DESCRIPTION
Fixes `extractPrincipal` function in `SecurityUtils`.
Before the cast to `JwtAuthenticationToken` were broken.